### PR TITLE
IBN-1489 add mime type to OK responses

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
@@ -392,7 +392,7 @@ public class ItemResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @PUT

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/link/ItemChannelLinkResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/link/ItemChannelLinkResource.java
@@ -84,7 +84,7 @@ public class ItemChannelLinkResource implements RESTResource {
     public Response link(@PathParam("itemName") @ApiParam(value = "itemName") String itemName,
             @PathParam("channelUID") @ApiParam(value = "channelUID") String channelUid) {
         itemChannelLinkRegistry.add(new ItemChannelLink(itemName, new ChannelUID(channelUid)));
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @DELETE
@@ -105,7 +105,7 @@ public class ItemChannelLinkResource implements RESTResource {
         ItemChannelLink result = itemChannelLinkRegistry
                 .remove(AbstractLink.getIDFor(itemName, new ChannelUID(channelUid)));
         if (result != null) {
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         } else {
             return JSONResponse.createErrorResponse(Status.METHOD_NOT_ALLOWED, "Channel is read-only.");
         }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -315,7 +315,7 @@ public class ThingResource implements RESTResource {
             }
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     /**


### PR DESCRIPTION
If the mime type is left, firefox will interpret the response as xml
and log a warning considering missing xml root.