### PR TITLE
IBN-535 remove old state listeners for arithmetic

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -282,6 +282,17 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String>implements I
                 // the group might not yet be registered, let's ignore this
             }
         }
+        // removes old state listeners that store the initial arithmetic operation on server start
+        for (Item groupItem : getItems("knxcom_function_*")) {
+			if (groupItem instanceof GroupItem) {
+				List<String> groupNames = ((GroupItem) groupItem).getGroupNames();
+				for (String groupName : groupNames) {
+					if (groupName.equals(item.getName())) {
+						((GenericItem) groupItem).removeStateChangeListener((GroupItem) item);
+					}
+				}
+			}
+        }
     }
 
     @Override


### PR DESCRIPTION
If an arithmetic function changes the logic link for example from
'and' to 'or', old statechangelistener remain in the added functions.
These listeners are added to notify the logic of state changes in any
added function which require the logic itself to revaluate, if itself
has to change the state. By removing the old statechangelisteners, new
ones will be added, which represent the correct logic link, when the
logic link changes.