### PR TITLE
IBN-1472: Make config description URI non-optional again

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
@@ -144,9 +144,6 @@ public class ConfigDescriptionRegistry {
 
         boolean found = false;
         for (ConfigDescriptionProvider configDescriptionProvider : this.configDescriptionProviders) {
-        	
-        	if ( uri == null ) break;
-        	
             ConfigDescription config = configDescriptionProvider.getConfigDescription(uri, locale);
 
             if (config != null) {


### PR DESCRIPTION
The original change, part of 12a9a3a, is obsoleted by AlJungOrg/liteserver#540 which fixes the same problem but in our application.