### PR TITLE
IBN-1716: Hue: Restore legacy XML thing type descriptions

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_A60_RGBW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_A60_RGBW.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- OSRAM Lightify Classic A60 RGB TunableWhite LED with E27 socket -->
+    <!-- OSRAM Lightify bulb will return as modelid: "Classic A60 RGBW", which will be converted from blanks to "-" -->
+    <thing-type id="Classic_A60_RGBW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Classic A60 RGBW LED</label>
+        <description>This is a standard OSRAM Lightify LED bulb with E27 socket as RGB / TunableWhite lamp</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+        </channels>
+        
+        <properties>
+        	<property name="vendor">OSRAM</property>
+        	<property name="modelId">Classic_A60_RGBW</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_A60_TW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_A60_TW.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="Classic_A60_TW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Tunable White (E27 socket)</label>
+        <description>This is a OSRAM Lightify Light as Tunable White lamp</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">OSRAM</property>
+            <property name="modelId">Classic A60 TW</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_B40_TW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_B40_TW.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="Classic_B40_TW___LIGHTIFY">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify PAR16 50 Light Tunable White (E14 socket)</label>
+        <description>This is a OSRAM Lightify PAR16 50 Light as Tunable White lamp</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">OSRAM</property>
+            <property name="modelId">Classic_B40_TW___LIGHTIFY</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DD_FLSH.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DD_FLSH.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="FLS_H3">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Dresden Elektronik Light Tunable White Lightstrip</label>
+        <description>This is a Dresden Elektronik Tunable White light Strip</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">DD</property>
+            <property name="modelId">FLS-PP3 White</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DD_FLSPP.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DD_FLSPP.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="FLS_PP3">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Dresden Elektronik RGBW LED-Strip</label>
+        <description>This is a Dresden Elektronik LED-Strip as RGB / TunableWhite</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+        </channels>
+        
+        <properties>
+        	<property name="vendor">DD</property>
+        	<property name="modelId">FLS-PP3</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Flex_RGBW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Flex_RGBW.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="Flex_RGBW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Flex RGBW Lightstrips</label>
+        <description>This is an OSRAM Lightify Flex RGBW light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">OSRAM</property>
+            <property name="modelId">Flex RGBW</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/GardenPole_RGBW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/GardenPole_RGBW.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="Gardenpole_RGBW_Lightify">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Gardenpole RGBW LED</label>
+        <description>This is a OSRAM Lightify LED Lightif as RGB / TunableWhite lamp</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+        </channels>
+        
+        <properties>
+        	<property name="vendor">OSRAM</property>
+        	<property name="modelId">"Gardenpole RGBW-Lightify""</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT001.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT001.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue Color Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT001">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Lamp</label>
+        <description>This is a standard Philips hue bulb with E27 socket (Hue bulb A19)</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT001</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT002.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT002.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue Color Downlight (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT002">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Downlight</label>
+        <description>This is a Philips hue spot BR30</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT002</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT003.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT003.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue Color Spot with GU10 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT003">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Spot</label>
+        <description>This is a Philips hue spot with GU10 socket</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT003</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT007.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT007.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue Color Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT007">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Lamp</label>
+        <description>This is a standard Philips hue bulb with E27 socket (Hue bulb A19)</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT007</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT010.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT010.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue Color Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT010">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Lamp</label>
+        <description>This is a standard Philips hue bulb with E27 socket (Hue bulb A19)</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT010</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT011.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT011.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue Color Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT011">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Lamp</label>
+        <description>This is a standard Philips hue bulb with E27 socket (Hue bulb A19)</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT011</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT012.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT012.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue Color Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT012">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue color candle</label>
+        <description>Hue color candle</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT012</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT014.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LCT014.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue Color Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LCT014">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Lamp</label>
+        <description>This is a standard Philips hue bulb with E27 socket (Hue bulb A19)</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LCT014</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC001.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC001.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Living Color Iris (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LLC001">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Living Color Gen2 Iris</label>
+        <description>This is a Philips Living Color Iris light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC001</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC006.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC006.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Living Color Iris (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LLC006">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Living Color Gen3 Iris</label>
+        <description>This is a Philips Living Color Iris light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC006</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC007.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC007.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Living Colors Aura (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LLC007">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Living Colors Gen3 Aura</label>
+        <description>This is a Philips Living Colors Aura light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC007</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC010.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC010.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Living Color Iris (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LLC010">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Living Color Iris</label>
+        <description>This is a Philips Living Color Iris light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC010</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC011.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC011.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Living Color Bloom (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LLC011">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Living Colors Bloom (v1)</label>
+        <description>This is a Philips Living Colors Bloom light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC011</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC012.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC012.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Living Color Bloom (see http://www.developers.meethue.com/documentation/supported-lights1) -->
+    <thing-type id="LLC012">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Living Colors Bloom (v2)</label>
+        <description>This is a Philips Living Colors Bloom light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC012</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC013.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC013.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Disney Living Colors (see http://www.developers.meethue.com/documentation/supported-lights1) -->
+    <thing-type id="LLC013">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Disney Living Colors (StoryLight)</label>
+        <description>This is a Philips Disney Living Colors light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC013</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC020.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LLC020.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips Hue Go (see http://www.developers.meethue.com/documentation/supported-lights1) -->
+    <thing-type id="LLC020">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Hue Go</label>
+        <description>This is a Philips Hue Go light</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LLC020</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LST001.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LST001.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips LightStrips (see http://www2.meethue.com/en-us/the-range/lightstrips/) -->
+    <thing-type id="LST001">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips LightStrips</label>
+        <description>This is a Philips LightStrip</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LST001</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LST002.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LST002.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips LightStrips (see http://www2.meethue.com/en-us/the-range/hue-lightstrip-plus/) -->
+    <thing-type id="LST002">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips Lightstrip Plus</label>
+        <description>This is a Philips Lightstrip Plus</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LST002</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC001.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC001.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue ambiance ceiling (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTC001">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue ambiance ceiling</label>
+        <description>TW</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTC001</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC002.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC002.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue ambiance ceiling (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTC002">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue ambiance ceiling</label>
+        <description>TW</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTC002</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC003.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC003.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue ambiance ceiling (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTC003">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue ambiance ceiling</label>
+        <description>TW</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTC003</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC004.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTC004.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue ambiance ceiling (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTC004">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue ambiance ceiling</label>
+        <description>TW</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTC004</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW001.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW001.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue TW Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTW001">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Standard Hue Tunable White (E27 socket)</label>
+        <description>Standard Hue Tunable White (E27 socket)</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTW001</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW004.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW004.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue TW Bulb with E27 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTW004">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Standard Hue Tunable White (E27 socket)</label>
+        <description>Standard Hue Tunable White (E27 socket)</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTW004</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW012.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW012.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue TW Bulb with GU10 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTW012">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Standard Hue Tunable White (GU10 socket)</label>
+        <description>Standard Hue Tunable White (GU10 socket)</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTW012</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW013.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW013.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Standard Hue TW Bulb with GU10 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTW013">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Standard Hue Tunable White (GU10 socket)</label>
+        <description>Standard Hue Tunable White (GU10 socket)</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTW013</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW014.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LTW014.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+     <!-- Standard Hue TW Bulb with GU10 socket (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="LTW014">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Standard Hue Tunable White (GU10 socket)</label>
+        <description>Standard Hue Tunable White (GU10 socket)</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LTW014</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB004.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB004.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue Lux with E27 socket (see http://www.everyhue.com/vanilla/discussion/47/model-ids/p1) -->
+    <thing-type id="LWB004">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Bulb</label>
+        <description>This is a Philips Hue Lux with E27 socket</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LWB004</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB006.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB006.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue Lux with E27 socket (see http://www.everyhue.com/vanilla/discussion/47/model-ids/p1) -->
+    <thing-type id="LWB006">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Bulb</label>
+        <description>This is a Philips Hue Lux with E27 socket</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LWB006</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB007.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB007.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue Lux with E27 socket (see http://www.everyhue.com/vanilla/discussion/47/model-ids/p1) -->
+    <thing-type id="LWB007">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Bulb</label>
+        <description>This is a Philips Hue Lux with E27 socket</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LWB007</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB010.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB010.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue Lux with E27 socket (see http://www.everyhue.com/vanilla/discussion/47/model-ids/p1) -->
+    <thing-type id="LWB010">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Bulb</label>
+        <description>This is a Philips Hue Lux with E27 socket</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LWB010</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB014.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWB014.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue Lux with E27 socket (see http://www.everyhue.com/vanilla/discussion/47/model-ids/p1) -->
+    <thing-type id="LWB014">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Hue Bulb</label>
+        <description>This is a Philips Hue Lux with E27 socket</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LWB014</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWL001.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/LWL001.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Philips LivingWhites Adapter (see http://www.philips.de/c-p/6916531PH/livingwhites) -->
+    <thing-type id="LWL001">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Philips LivingWhites Adapter</label>
+        <description>This is a Philips LivingWhites adapter</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Philips</property>
+            <property name="modelId">LWL001</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Outdoor_FLEX_RGBW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Outdoor_FLEX_RGBW.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="LIGHTIFY_Outdoor_Flex_RGBW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Outdoor Flex RGBW LED</label>
+        <description>This is a OSRAM Lightify LED Lightstrip as RGB / TunableWhite lamp</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+        </channels>
+        
+        <properties>
+        	<property name="vendor">OSRAM</property>
+        	<property name="modelId">LIGHTIFY Outdoor Flex RGBW</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PAR16_50_RGBW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PAR16_50_RGBW.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="PAR_16_50_RGBW___LIGHTIFY">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify PAR16 50 RGBW (GU10 socket)</label>
+        <description>This is a OSRAM Lightify PAR16 50 Light as RGBW lamp</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">OSRAM</property>
+            <property name="modelId">PAR_16_50_RGBW___LIGHTIFY</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PAR16_50_TW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PAR16_50_TW.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- OSRAM Lightify PAR16 50 Light Tunable White (GU10 Bulb fitting) -->
+    <!-- OSRAM Lightify PAR16 50 bulb will return as modelid: "PAR16 50 TW", which will be converted from blanks to "_" -->
+    <thing-type id="PAR16_50_TW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify PAR16 50 Light Tunable White (GU10 socket)</label>
+        <description>This is a OSRAM Lightify PAR16 50 Light as Tunable White lamp</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">OSRAM</property>
+            <property name="modelId">PAR16_50_TW</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_JZD60_J4R150.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_JZD60_J4R150.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="JZD60_J4R150">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Paul Neuhaus</label>
+        <description>RGBW</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Paul Neuhaus</property>
+            <property name="modelId">JZD60-J4R150</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_JZD60_J4W150.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_JZD60_J4W150.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="JZD60_J4W150">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Paul Neuhaus</label>
+        <description>TW</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Paul Neuhaus</property>
+            <property name="modelId">JZD60-J4W150</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_JZ_RGBW_Z01.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_JZ_RGBW_Z01.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="JZ_RGBW_Z01">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Paul Neuhaus</label>
+        <description>RGBW</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Paul Neuhaus</property>
+            <property name="modelId">JN-JZ-RGBW-Z01</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_NLG-CCT.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_NLG-CCT.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Hue ambiance ceiling (see http://www.developers.meethue.com/documentation/supported-lights) -->
+    <thing-type id="NLG_CCT_light_">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Paul Neuhaus</label>
+        <description>TW</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+        
+        <properties>
+            <property name="vendor">Paul Neuhaus</property>
+            <property name="modelId">NLG-CCT light </property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_NLG_RGBW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/PN_NLG_RGBW.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="NLG_RGBW_light_">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>Paul Neuhaus</label>
+        <description>RGBW</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+            <channel id="alert" typeId="alert" />
+            <channel id="effect" typeId="effect" />
+        </channels>
+
+        <properties>
+            <property name="vendor">Paul Neuhaus</property>
+            <property name="modelId">NLG-RGBW light</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Surface_Light_TW.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Surface_Light_TW.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- OSRAM Lightify Surface Light Tunable White  -->
+    <!-- OSRAM Lightify bulb will return as modelid: "Surface Light TW", which will be converted from blanks to "-" -->
+    <thing-type id="Surface_Light_TW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Surface Light Tunable White</label>
+        <description>This is a OSRAM Lightify Surface Light as Tunable White lamp</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+        </channels>
+        
+        <properties>
+        	<property name="vendor">OSRAM</property>
+        	<property name="modelId">Surface_Light_TW</property>
+        </properties>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ZLL_Light.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ZLL_Light.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- Generic ZigBee LightLink Bulb -->
+    <thing-type id="ZLL_Light">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>ZigBee LightLink Bulb</label>
+        <description>This is a generic ZigBee LightLink Bulb</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness" />
+        </channels>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>


### PR DESCRIPTION
Without these descriptions, the hue binding cannot create things with the legacy hue thing types, which old backup files may still contain.