### PR TITLE
IBN-1682 set correct listener in logic member groupitem

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -276,6 +276,9 @@ abstract public class GenericItem implements ActiveItem {
 
     public void addStateChangeListener(StateChangeListener listener) {
         synchronized (listeners) {
+            if (listeners.contains(listener))  {
+                this.removeStateChangeListener(listener);
+            }
             listeners.add(listener);
         }
     }


### PR DESCRIPTION
When deleting a logic function the group item remains as a listener
in the member and thus the reference keeps the garbage collector from
relieving the group item object of the deleted logic function. When
the new logic function is created with identical unique identifiers
the listener won't get updated in the member since the child object
in the inheritance overrides the equal method of the java library.
This means when trying to add the new listener in the set the equals
method is used to prevent doubled items in the set. Since the overriden
equals method determines the listeners to be the same, the old one
will remain and the new one is never set. Thus updates to the status
logic wont persist through the event cycle. The old listeners are
never removed because the item removal process masks the group item
to be deleted with a newly created one. Since that has no runtime added
listeners, the listener isn't existent for removal on the new group
item. In the current project structure this isn't easily fixed tho.