### PR TITLE
IBN-1724 introduce new event type GroupItemStateEvent

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -350,6 +350,8 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         }
         if (!oldState.equals(this.state)) {
             sendGroupStateChangedEvent(item.getName(), this.state, oldState);
+        } else {
+            sendGroupStateEvent(item.getName(), this.state);
         }
     }
 
@@ -369,6 +371,13 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         if (eventPublisher != null) {
             eventPublisher.post(
                     ItemEventFactory.createGroupStateChangedEvent(this.getName(), memberName, newState, oldState));
+        }
+    }
+
+    private void sendGroupStateEvent(String memberName, State state) {
+        if (eventPublisher != null) {
+            eventPublisher.post(
+                    ItemEventFactory.createGroupStateEvent(this.getName(), memberName, state));
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateEvent.java
@@ -1,0 +1,63 @@
+package org.eclipse.smarthome.core.items.events;
+
+import org.eclipse.smarthome.core.events.AbstractEvent;
+import org.eclipse.smarthome.core.types.State;
+
+/**
+ * {@link GroupItemStateEvent}s can be used to deliver groupitem status updates through the Eclipse SmartHome event bus.
+ * State events must be created with the {@link ItemEventFactory}.
+ *
+ * @author MAW
+ *
+ */
+public class GroupItemStateEvent extends AbstractEvent {
+
+    public final static String TYPE = ItemStateEvent.class.getSimpleName();
+
+    private final String itemName;
+
+    private final State itemState;
+
+    /**
+     * Constructs a new groupitem state event.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param itemName the item name
+     * @param itemState the item state
+     * @param source the source, can be null
+     */
+    protected GroupItemStateEvent(String topic, String payload, String itemName, State itemState, String source) {
+        super(topic, payload, source);
+        this.itemName = itemName;
+        this.itemState = itemState;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Gets the item name.
+     *
+     * @return the item name
+     */
+    public String getItemName() {
+        return itemName;
+    }
+
+    /**
+     * Gets the item state.
+     *
+     * @return the item state
+     */
+    public State getItemState() {
+        return itemState;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s updated to %s", itemName, itemState);
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -53,6 +53,8 @@ public class ItemEventFactory extends AbstractEventFactory {
 
     private static final String ITEM_STATE_CHANGED_EVENT_TOPIC = "smarthome/items/{itemName}/statechanged";
 
+    private static final String GROUPITEM_STATE_EVENT_TOPIC = "smarthome/items/{itemName}/{memberName}/state";
+
     private static final String GROUPITEM_STATE_CHANGED_EVENT_TOPIC = "smarthome/items/{itemName}/{memberName}/statechanged";
 
     private static final String ITEM_ADDED_EVENT_TOPIC = "smarthome/items/{itemName}/added";
@@ -283,6 +285,36 @@ public class ItemEventFactory extends AbstractEventFactory {
                 newState.toFullString(), getStateType(oldState), oldState.toFullString());
         String payload = serializePayload(bean);
         return new ItemStateChangedEvent(topic, payload, itemName, newState, oldState);
+    }
+
+    /**
+     * Creates a group item state event.
+     *
+     * @param itemName the name of the group item to send the state update for
+     * @param memberName the name of the member item which was updated
+     * @param state the new state to send
+     * @param source the name of the source identifying the sender (can be null)
+     * @return the created group item state event
+     */
+    public static GroupItemStateEvent createGroupStateEvent(String itemName, String memberName,
+                State state, String source) {
+        assertValidArguments(itemName, memberName, state, "state");
+        String topic = buildGroupTopic(GROUPITEM_STATE_EVENT_TOPIC, itemName, memberName);
+        ItemEventPayloadBean bean = new ItemEventPayloadBean(getStateType(state), state.toFullString());
+        String payload = serializePayload(bean);
+        return new GroupItemStateEvent(topic, payload, itemName, state, source);
+    }
+
+    /**
+     * Creates a group item state event.
+     *
+     * @param itemName the name of the group item to send the state update for
+     * @param memberName the name of the member item which was updated
+     * @param state the new state to send
+     * @return the created group item state event
+     */
+    public static GroupItemStateEvent createGroupStateEvent(String itemName, String memberName, State state) {
+        return createGroupStateEvent(itemName, memberName, state, null);
     }
 
     public static GroupItemStateChangedEvent createGroupStateChangedEvent(String itemName, String memberName,


### PR DESCRIPTION
The new event gets send when a group item member updates but no
change is published. Items recieve an itemStateEvent but groups
didn't get notified about an update. This "blocked" the action
executor from triggering "every"-actions since no events where
recieved for an update of logic functions.