### PR TITLE
IBN-1731: GroupItem: Send GroupItemStateEvent for calculated state

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -346,12 +346,11 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         if (function != null && baseItem != null) {
             State calculatedState = function.calculate(getMembers());
             calculatedState = ItemUtil.convertToAcceptedState(calculatedState, baseItem);
+            sendGroupStateEvent(item.getName(), calculatedState);
             setState(calculatedState);
         }
         if (!oldState.equals(this.state)) {
             sendGroupStateChangedEvent(item.getName(), this.state, oldState);
-        } else {
-            sendGroupStateEvent(item.getName(), this.state);
         }
     }
 


### PR DESCRIPTION
The GroupItemStateEvent we recently introduced differs semantically from regular ItemStateEvent:

* ItemStateEvent is fired _before_ ItemStateChangedEvent, not instead of it
* ItemStateEvent is fired _regardless of_ whether there was a change in state, not only if there was none
* ItemStateEvent is fired _before_ the item state is actually updated
* ItemStateEvent is fired _if_ the item accepts the incoming state

The differences in handling cause some problems, IBN-1731 among them.

This change aims to eliminate the changes by
* firing the event before applying the new state
* but only of the group has a function
  (which indicates that the group can have state at all)