### PR TITLE
Define versions for maven-install-plugin and maven-deploy-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,15 @@
 
     <pluginManagement>
       <plugins>
+       <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
         <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+         <plugin>
           <groupId>${tycho-groupid}</groupId>
           <artifactId>target-platform-configuration</artifactId>
           <version>${tycho-version}</version>


### PR DESCRIPTION
This fixes the same problems as eclipse/smarthome#6294 and eclipse/smarthome#6323.

See also openhab/openhab-core#408.