### PR TITLE
IBN-2098: Pin gulp-inject version

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -38,7 +38,7 @@
     "gulp": "^3.9.0",
     "gulp-angular-filesort": "~1.1.1",
     "gulp-concat": "^2.6.0",
-    "gulp-inject": "^4.0.0",
+    "gulp-inject": "4.3.2",
     "gulp-ng-annotate": "~1.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.1",


### PR DESCRIPTION
The current version range allows for either gulp-inject 4.3.2 or 4.3.3 to be installed.
Version 4.3.2 depends on ansi-color 1.1.0, which is fine,
while version 4.3.3 depends on ansi-color 3, which requires node 6 and breaks the build.
Upgrading node itself leads to other seemingly unrelated errors
(failure to git clone some github wikis during npm install, but only on jenkins)
which makes this not an option.

This change pins gulp-inject to the known working version.