### PR TITLE
IBN-2390 remove recommendation to skip commands for offline things

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/AutoUpdateManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/AutoUpdateManager.java
@@ -199,10 +199,6 @@ public class AutoUpdateManager {
             }
             onlineChannelUIDs.add(channelUID);
         }
-        if (!linkedChannelUIDs.isEmpty() && onlineChannelUIDs.isEmpty()) {
-            // none of the linked channels is able to process the command
-            return Recommendation.REVERT;
-        }
 
         for (ChannelUID channelUID : onlineChannelUIDs) {
             Thing thing = thingRegistry.get(channelUID.getThingUID());


### PR DESCRIPTION
When the autoupdatemanager received a command and the channels all were offline, which is the case with no knx connection, the default behaviour was to recommend a skip of the command since the newer esh version.