### PR TITLE
IBN-2581 enable calls through https for hue defaulting to http

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/internal/MockedHttpClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/internal/MockedHttpClient.java
@@ -13,5 +13,7 @@
 package org.eclipse.smarthome.binding.hue.internal;
 
 public class MockedHttpClient extends HttpClient {
-
+    public MockedHttpClient() {
+        super("1.2.3.4");
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
@@ -59,7 +59,7 @@ public class HueBridge {
     private @Nullable String username;
 
     private final Gson gson = new GsonBuilder().setDateFormat(DATE_FORMAT).create();
-    private HttpClient http = new HttpClient();
+    private HttpClient http;
     private final ScheduledExecutorService scheduler;
 
     @Nullable
@@ -73,6 +73,7 @@ public class HueBridge {
     public HueBridge(String ip, ScheduledExecutorService scheduler) {
         this.ip = ip;
         this.scheduler = scheduler;
+        this.http = new HttpClient(ip);
     }
 
     /**
@@ -88,6 +89,7 @@ public class HueBridge {
     public HueBridge(String ip, String username, ScheduledExecutorService scheduler) throws IOException, ApiException {
         this.ip = ip;
         this.scheduler = scheduler;
+        this.http = new HttpClient(ip);
         authenticate(username);
     }
 
@@ -811,7 +813,7 @@ public class HueBridge {
     private @Nullable ScheduleCommand handleCommandCallback(ScheduleCallback callback) throws ApiException {
         // Temporarily reroute requests to a fake HTTP client
         HttpClient realClient = http;
-        http = new HttpClient() {
+        http = new HttpClient(this.ip) {
             @Override
             protected Result doNetwork(String address, String requestMethod, @Nullable String body) throws IOException {
                 // GET requests cannot be scheduled, so will continue working normally for convenience
@@ -1061,7 +1063,7 @@ public class HueBridge {
     }
 
     private String getRelativeURL(String path) {
-        String relativeUrl = "http://" + ip + "/api";
+        String relativeUrl = "/api";
         if (username != null) {
             relativeUrl += "/" + enc(username);
         }


### PR DESCRIPTION
The default back to http is used for compability to older hardware and
the phoscon gateway. The connection now uses ssl/tls without a proper
check for host or certificate. Mainly the deprecation of http for hue
made these changes necessary.