### PR TITLE
IBN-2419 prevent status flashing when bridge not reachable

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
@@ -862,11 +862,12 @@ public class HueBridge {
 
     /**
      * Authenticate on the bridge as the specified user.
-     * This function verifies that the specified username is valid and will use
-     * it for subsequent requests if it is, otherwise an UnauthorizedException
-     * is thrown and the internal username is not changed.
+     * This function verifies that the specified username is valid, otherwise an
+     * UnauthorizedException is thrown. If the bridge is not reachable an
+     * IOException will be thrown.
      *
      * @param username username to authenticate
+     * @throws IOException thrown if the bridge is not reachable
      * @throws UnauthorizedException thrown if authentication failed
      */
     public void authenticate(String username) throws IOException, ApiException {
@@ -874,8 +875,7 @@ public class HueBridge {
             this.username = username;
             getLights();
         } catch (Exception e) {
-            this.username = null;
-            throw new UnauthorizedException(e.toString());
+            throw e;
         }
     }
 


### PR DESCRIPTION
The polling detection of the bridge status got overhauled. The correct
status and description should now be shown.