### PR TITLE
IBN-2808 let osgi handle hue bridge discovery service injection

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/.gitignore
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/.gitignore
@@ -1,1 +1,2 @@
 /*.xml
+!org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource.xml

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource">
+    <implementation class="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource"/>
+    <service>
+        <provide interface="org.eclipse.smarthome.io.rest.RESTResource"/>
+        <provide interface="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource"/>
+    </service>
+    <reference bind="setHueBridgeNupnpDiscovery" cardinality="1..1" interface="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery" name="HueBridgeNupnpDiscovery" policy="static" unbind="unsetHueBridgeNupnpDiscovery"/>
+</scr:component>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/ManualDiscoveryResource.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/ManualDiscoveryResource.java
@@ -27,7 +27,6 @@ import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.core.auth.Role;
 import org.eclipse.smarthome.io.rest.JSONResponse;
 import org.eclipse.smarthome.io.rest.RESTResource;
-import org.osgi.service.component.annotations.Component;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -44,7 +43,6 @@ import io.swagger.annotations.ApiResponses;
 @Path(ManualDiscoveryResource.PATH_DISCOVERY)
 @RolesAllowed({ Role.ADMIN })
 @Api(value = ManualDiscoveryResource.PATH_DISCOVERY)
-@Component(service = { RESTResource.class, ManualDiscoveryResource.class })
 public class ManualDiscoveryResource implements RESTResource {
 
     /** The URI path to this resource */
@@ -61,14 +59,20 @@ public class ManualDiscoveryResource implements RESTResource {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = String.class) })
     public Response putDiscovery(@PathParam("ip") @ApiParam(value = "ip") final String ip) {
-        if (this.hueBridgeNupnpDiscovery == null) {
-            this.hueBridgeNupnpDiscovery = new HueBridgeNupnpDiscovery();
-        }
         DiscoveryResult bridge = this.hueBridgeNupnpDiscovery.addDiscovery(ip);
         if (bridge == null) {
             return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Bridge not found");
         }
         return Response.ok(bridge).build();
+    }
+
+
+    protected void setHueBridgeNupnpDiscovery(HueBridgeNupnpDiscovery hueBridgeNupnpDiscovery) {
+        this.hueBridgeNupnpDiscovery = hueBridgeNupnpDiscovery;
+    }
+
+    protected void unsetHueBridgeNupnpDiscovery(HueBridgeNupnpDiscovery hueBridgeNupnpDiscovery) {
+        this.hueBridgeNupnpDiscovery = null;
     }
 
 }


### PR DESCRIPTION
The service is now properly injected via osgi instead of constructing
it. This ensures the references from the injected service to also be
resolved and manual ip discovery to function.