### PR TITLE
IBN-2966 fix osgi dependencies with static configurations

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/.gitignore
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/.gitignore
@@ -1,2 +1,0 @@
-/*.xml
-!org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource.xml

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.HueThingHandlerFactory.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.HueThingHandlerFactory.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" name="org.eclipse.smarthome.binding.hue.internal.HueThingHandlerFactory" configuration-pid="binding.hue">
+    <service>
+        <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+    </service>
+    <implementation class="org.eclipse.smarthome.binding.hue.internal.HueThingHandlerFactory"/>
+</scr:component>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeDiscoveryParticipant.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeDiscoveryParticipant.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.0.0" name="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeDiscoveryParticipant">
+    <service>
+        <provide interface="org.eclipse.smarthome.config.discovery.upnp.UpnpDiscoveryParticipant"/>
+    </service>
+    <implementation class="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeDiscoveryParticipant"/>
+</scr:component>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" configuration-pid="discovery.hue" name="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery">
+   <service>
+      <provide interface="org.eclipse.smarthome.config.discovery.DiscoveryService"/>
+      <provide interface="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery"/>
+   </service>
+   <implementation class="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery"/>
+</scr:component>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/OSGI-INF/org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource">
-    <implementation class="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource"/>
-    <service>
-        <provide interface="org.eclipse.smarthome.io.rest.RESTResource"/>
-        <provide interface="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource"/>
-    </service>
-    <reference bind="setHueBridgeNupnpDiscovery" cardinality="1..1" interface="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery" name="HueBridgeNupnpDiscovery" policy="static" unbind="unsetHueBridgeNupnpDiscovery"/>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource">
+   <service>
+      <provide interface="org.eclipse.smarthome.io.rest.RESTResource"/>
+   </service>
+   <reference bind="setHueBridgeNupnpDiscovery" interface="org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeNupnpDiscovery" name="HueBridgeNupnpDiscovery" unbind="unsetHueBridgeNupnpDiscovery"/>
+   <implementation class="org.eclipse.smarthome.binding.hue.internal.discovery.ManualDiscoveryResource"/>
 </scr:component>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
@@ -40,9 +40,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
-import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.component.annotations.Component;
 
 /**
  * {@link HueThingHandlerFactory} is a factory for {@link HueBridgeHandler}s.
@@ -54,7 +52,6 @@ import org.osgi.service.component.annotations.Component;
  * @author Christoph Weitkamp - Added support for sensor API
  */
 @NonNullByDefault
-@Component(service = ThingHandlerFactory.class, configurationPid = "binding.hue")
 public class HueThingHandlerFactory extends BaseThingHandlerFactory {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(Stream
             .of(HueBridgeHandler.SUPPORTED_THING_TYPES.stream(), HueLightHandler.SUPPORTED_THING_TYPES.stream(),

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -30,7 +30,6 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.jupnp.model.meta.DeviceDetails;
 import org.jupnp.model.meta.ModelDetails;
 import org.jupnp.model.meta.RemoteDevice;
-import org.osgi.service.component.annotations.Component;
 
 /**
  * The {@link HueBridgeDiscoveryParticipant} is responsible for discovering new and
@@ -40,7 +39,6 @@ import org.osgi.service.component.annotations.Component;
  * @author Thomas Höfer - Added representation
  */
 @NonNullByDefault
-@Component(service = UpnpDiscoveryParticipant.class, immediate = true)
 public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
@@ -29,11 +29,9 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
-import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +48,6 @@ import com.google.gson.reflect.TypeToken;
  * @author Andre Fuechsel - make {@link #startScan()} asynchronous
  */
 @NonNullByDefault
-@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.hue")
 public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
 
     private static final String MODEL_NAME_PHILIPS_HUE = "<modelName>Philips hue";


### PR DESCRIPTION
The generated files were too hard to control savely and are a deprecated
use in the project anyways. Now that we don't ignore those files
anymore, we can also be sure to have the same on every system or else we
will see in the versioning system what's changed.